### PR TITLE
Add span filter to http middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/shawnfeng/consistent v1.0.3
 	github.com/shawnfeng/dbrouter v1.0.2
 	github.com/shawnfeng/hystrix-go v0.0.0-20190320120533-5e2bc39f173a
-	github.com/shawnfeng/sutil v1.3.9
+	github.com/shawnfeng/sutil v1.3.22
 
 	// nn
 	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect

--- a/util/service/Service.go
+++ b/util/service/Service.go
@@ -254,6 +254,9 @@ func (m *Service) Init(confEtcd configEtcd, args *cmdArgs, initfn func(ServBase)
 	defer slog.Sync()
 	defer statlog.Sync()
 
+	// NOTE: processor 在初始化 trace middleware 前需要保证 opentracing.GlobalTracer() 初始化完毕
+	m.initTracer(servLoc)
+
 	m.initBackdoork(sb)
 
 	err = m.handleModel(sb, servLoc, args.model)
@@ -267,9 +270,6 @@ func (m *Service) Init(confEtcd configEtcd, args *cmdArgs, initfn func(ServBase)
 		slog.Panicf("%s callInitFunc err:%s", fun, err)
 		return err
 	}
-
-	// NOTE: processor 在初始化 trace middleware 前需要保证 opentracing.GlobalTracer() 初始化完毕
-	m.initTracer(servLoc)
 
 	err = m.initProcessor(sb, procs)
 	if err != nil {

--- a/util/service/power.go
+++ b/util/service/power.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/shawnfeng/sutil/slog"
 	"github.com/shawnfeng/sutil/snetutil"
+	"github.com/shawnfeng/sutil/trace"
 	"net"
 	"net/http"
 )
@@ -52,7 +53,8 @@ func powerHttp(addr string, router *httprouter.Router) (string, error) {
 		httpTrafficLogMiddleware(router),
 		nethttp.OperationNameFunc(func(r *http.Request) string {
 			return "HTTP " + r.Method + ": " + r.URL.Path
-		}))
+		}),
+		nethttp.MWSpanFilter(trace.UrlSpanFilter))
 
 	go func() {
 		err := http.Serve(netListen, mw)
@@ -169,7 +171,8 @@ func powerGin(addr string, router *gin.Engine) (string, *http.Server, error) {
 		httpTrafficLogMiddleware(router),
 		nethttp.OperationNameFunc(func(r *http.Request) string {
 			return "HTTP " + r.Method + ": " + r.URL.Path
-		}))
+		}),
+		nethttp.MWSpanFilter(trace.UrlSpanFilter))
 
 	serv := &http.Server{Handler: mw}
 	go func() {


### PR DESCRIPTION
backdoor会启动http服务，所以将trace初始化逻辑也提到backdoor之前（不过这样trace会在获取分布式锁之前就初始化，但这样也没有问题）