### PR TITLE
fix route nil list, add warn log in backup default route

### DIFF
--- a/util/service/registry.go
+++ b/util/service/registry.go
@@ -568,7 +568,7 @@ func (m *ClientEtcdV2) GetAllServAddrWithGroup(group, processor string) []*ServI
 	m.muServlist.Lock()
 	defer m.muServlist.Unlock()
 
-	servs := make([]*ServInfo, 0)
+	var servs []*ServInfo
 	for _, c := range m.servCopy {
 		if c.reg != nil {
 			if c.manual != nil && c.manual.Ctrl != nil && c.manual.Ctrl.Disable {

--- a/util/service/router.go
+++ b/util/service/router.go
@@ -97,16 +97,17 @@ func (m *Concurrent) Route(ctx context.Context, processor, key string) *ServInfo
 	group := xcontext.GetControlRouteGroupWithDefault(ctx, xcontext.DefaultGroup)
 	s := m.route(group, processor, key)
 	if s != nil {
-		xlog.Infof(ctx, "%s group: %s, processor: %s, key: %s, router: %v", fun, group, processor, key, s)
+		xlog.Debugf(ctx, "%s group: %s, processor: %s, key: %s, router: %v", fun, group, processor, key, s)
 		return s
 	}
 
 	s = m.route("", processor, key)
+	xlog.Errorf(ctx, "%s route to group error and back to default, group: %s, processor: %s, key: %s, router: %v", fun, group, processor, key, s)
 	return s
 }
 
 func (m *Concurrent) route(group, processor, key string) *ServInfo {
-	fun := "route -->"
+	fun := "Concurrent.route -->"
 
 	list := m.cb.GetAllServAddrWithGroup(group, processor)
 	if list == nil {
@@ -167,6 +168,8 @@ func (m *Addr) Route(ctx context.Context, processor, addr string) (si *ServInfo)
 	servList := m.cb.GetAllServAddrWithGroup(group, processor)
 
 	if servList == nil {
+		xlog.Infof(context.Background(), "%s processor: %s, group: %s, servKey: %s, servPath: %s, server info list is nil",
+			fun, processor, group, m.cb.ServKey(), m.cb.ServPath())
 		return
 	}
 

--- a/util/service/router.go
+++ b/util/service/router.go
@@ -102,7 +102,7 @@ func (m *Concurrent) Route(ctx context.Context, processor, key string) *ServInfo
 	}
 
 	s = m.route("", processor, key)
-	xlog.Errorf(ctx, "%s route to group error and back to default, group: %s, processor: %s, key: %s, router: %v", fun, group, processor, key, s)
+	xlog.Warnf(ctx, "%s route to group error and back to default, group: %s, processor: %s, key: %s, router: %v", fun, group, processor, key, s)
 	return s
 }
 


### PR DESCRIPTION
- 修复路由列表为空时的判断逻辑问题
- Concurrent路由策略, 当泳道路由找不到, 回退为主干路由时, 打warn日志 (这个不能去掉)