### PR TITLE
chore: bump go-stdlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	gitlab.pri.ibanyu.com/middleware/util v1.2.21-0.20201112030807-67e99b989e3b
 	gitlab.pri.ibanyu.com/server/servmonitor/pub.git v0.0.0-20201104035512-0152ae98fa6a
 	gitlab.pri.ibanyu.com/tracing/go-grpc v0.0.0-20201117083632-fd2d4bfc37a7
-	gitlab.pri.ibanyu.com/tracing/go-stdlib v1.0.1-0.20201117115444-9e64d49279d6
+	gitlab.pri.ibanyu.com/tracing/go-stdlib v1.0.1-0.20201122045811-4c0680a69dbf
 	google.golang.org/grpc v1.24.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -656,6 +656,7 @@ gitlab.pri.ibanyu.com/tracing/go-stdlib v1.0.1-0.20201116034204-1c212862c5cb h1:
 gitlab.pri.ibanyu.com/tracing/go-stdlib v1.0.1-0.20201116034204-1c212862c5cb/go.mod h1:c22Cd1TTV501GgNoTmGSCD7y192kKBhXdgrWA+QGmU0=
 gitlab.pri.ibanyu.com/tracing/go-stdlib v1.0.1-0.20201117115444-9e64d49279d6 h1:30N4v5ZeJ1rZg31h8s5KREHoIx7KxpqJoN6GjA7L6r8=
 gitlab.pri.ibanyu.com/tracing/go-stdlib v1.0.1-0.20201117115444-9e64d49279d6/go.mod h1:c22Cd1TTV501GgNoTmGSCD7y192kKBhXdgrWA+QGmU0=
+gitlab.pri.ibanyu.com/tracing/go-stdlib v1.0.1-0.20201122045811-4c0680a69dbf/go.mod h1:c22Cd1TTV501GgNoTmGSCD7y192kKBhXdgrWA+QGmU0=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=


### PR DESCRIPTION
bump go-stdlib. In the new version, span's error tag will be set only when there is a panic or the http response code is larger than or equal to 500.