### PR TITLE
load request logging config from namespace `rpc.server` (instead of `application`）

### DIFF
--- a/util/service/server_grpc.go
+++ b/util/service/server_grpc.go
@@ -347,7 +347,7 @@ func shouldLogRequest(fullMethod string) bool {
 	printBodyMethod := printBodyMethod{}
 
 	// 方法配置
-	_ = center.Unmarshal(context.Background(), &printBodyMethod)
+	_ = center.UnmarshalWithNamespace(context.Background(), RPCServerConfNamespace, &printBodyMethod)
 	// 不打印的优先级更高
 	if methodInList(methodName, printBodyMethod.NoLogRequestMethodList) {
 		return false

--- a/util/service/server_http.go
+++ b/util/service/server_http.go
@@ -500,7 +500,7 @@ func shouldHttpLogRequest(path string) bool {
 	printBodyMethod := printBodyMethod{}
 
 	// 方法配置
-	_ = center.Unmarshal(context.Background(), &printBodyMethod)
+	_ = center.UnmarshalWithNamespace(context.Background(), RPCServerConfNamespace, &printBodyMethod)
 	// 不打印的优先级更高
 	if methodInList(path, printBodyMethod.NoLogRequestMethodList) {
 		return false

--- a/util/service/service.go
+++ b/util/service/service.go
@@ -64,8 +64,9 @@ const (
 	ENV_GROUP_PRE = "pre"
 
 	// RPCConfNamespace RPC Apollo Conf Namespace
-	RPCConfNamespace     = "rpc.client"
-	ApplicationNamespace = "application"
+	RPCConfNamespace       = "rpc.client"
+	RPCServerConfNamespace = "rpc.server"
+	ApplicationNamespace   = "application"
 
 	serverStatusStop         = 1
 	DefaultEtcdClientTimeout = 3 * time.Second
@@ -500,7 +501,7 @@ func newServBaseV2WithCmdArgs(confEtcd configEtcd, args *cmdArgs) (*ServBaseV2, 
 
 	// init global config center
 	xlog.Infof(ctx, " %s init configcenter start", fun)
-	configCenter, err := xconfig.NewConfigCenter(context.TODO(), apollo.ConfigTypeApollo, args.servLoc, []string{ApplicationNamespace, RPCConfNamespace, xsql.MysqlConfNamespace, xmgo.MongoConfNamespace})
+	configCenter, err := xconfig.NewConfigCenter(context.TODO(), apollo.ConfigTypeApollo, args.servLoc, []string{ApplicationNamespace, RPCConfNamespace, RPCServerConfNamespace, xsql.MysqlConfNamespace, xmgo.MongoConfNamespace})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We do this to avoid performance regression.

When loading request logging config, we have to use config center's `Unmarshal` method, which will iterate ALL the keys in corresponding namespace. With lots of config in namespace `application`, performance decreases rapidly.