### PR TITLE
unregister etcd bug fix

### DIFF
--- a/util/service/cross_dc_register.go
+++ b/util/service/cross_dc_register.go
@@ -97,13 +97,8 @@ func (m *ServBaseV2) clearCrossDCRegisterInfos() {
 	m.muReg.Lock()
 	defer m.muReg.Unlock()
 
-	for addr, _ := range m.crossRegisterClients {
-		for path, _ := range m.regInfos {
-			ctx := context.Background()
-			delSidNodeInEtcd(ctx, path, m.crossRegisterClients[addr])
-			delSkeyInEtcd(ctx, path, m.etcdClient)
-			break
-		}
+	for _, etcdClient := range m.crossRegisterClients {
+		m.clearRegisterInfosInEtcd(context.Background(), etcdClient)
 	}
 }
 


### PR DESCRIPTION
之前删除时，两个目录 /roc/dist 和 /roc/dist2 只能删除一个，而删除dist2的目录不成功会影响调用方。本次修改将这两个目录下当前实例的信息都删除掉。