### PR TITLE
fix potential mutext conflict between `doCrossDCRegister` and `doRegister`

### DIFF
--- a/util/service/service.go
+++ b/util/service/service.go
@@ -115,11 +115,6 @@ type ServBaseV2 struct {
 	regInfos map[string]string
 }
 
-func (m *ServBaseV2) isStop() bool {
-	stopStatus := atomic.LoadInt32(&m.stop)
-	return stopStatus == serverStatusStop
-}
-
 // Stop server stop
 func (m *ServBaseV2) Stop() {
 	f := "ServBaseV2.Stop -->"
@@ -362,10 +357,10 @@ func (m *ServBaseV2) doRegister(path, js string, refresh bool) error {
 	ctx := context.Background()
 	m.addRegisterInfo(path, js)
 
-	// 创建完成标志
-	var isCreated bool
-
 	go func() {
+		// 创建完成标志
+		var isCreated bool
+
 		for i := 0; ; i++ {
 			updateEtcd := func() {
 				var err error
@@ -387,7 +382,6 @@ func (m *ServBaseV2) doRegister(path, js string, refresh bool) error {
 							TTL: time.Second * 60,
 						})
 					}
-
 				}
 
 				if err != nil {
@@ -399,12 +393,11 @@ func (m *ServBaseV2) doRegister(path, js string, refresh bool) error {
 				}
 			}
 
-			withRegLockRunClosureBeforeStop(m, ctx, fun, updateEtcd)
-
-			time.Sleep(time.Second * 20)
-
-			if m.isStop() {
-				xlog.Infof(ctx, "%s server stop, register path [%s] clear", fun, path)
+			if !m.IsStopped() {
+				updateEtcd()
+				time.Sleep(time.Second * 20)
+			} else {
+				xlog.Infof(ctx, "%s server stop, register info [%s] clear", fun, path)
 				return
 			}
 		}
@@ -601,26 +594,6 @@ func (m *ServBaseV2) createControlWithLaneInfo() *thriftutil.Control {
 	return control
 }
 
-// mutex
-
-func withRegLockRunClosureBeforeStop(m *ServBaseV2, ctx context.Context, funcName string, f func()) {
-	startTime := time.Now()
-	m.muReg.Lock()
-	xlog.Infof(ctx, "%s lock muReg for update", funcName)
-	defer func() {
-		m.muReg.Unlock()
-		duration := time.Since(startTime)
-		xlog.Infof(ctx, "%s unlock muReq for update, duration: %v", funcName, duration)
-	}()
-
-	if m.isStop() {
-		xlog.Infof(ctx, "%s server stop, do not run function", funcName)
-		return
-	}
-
-	f()
-}
-
 func genSid(client etcd.KeysAPI, path, skey string) (int, error) {
 	fun := "genSid -->"
 	ctx := context.Background()
@@ -712,5 +685,5 @@ func (m *ServBaseV2) Region() string {
 }
 
 func (m *ServBaseV2) IsStopped() bool {
-	return m.isStop()
+	return atomic.LoadInt32(&m.stop) == serverStatusStop
 }


### PR DESCRIPTION
这两个函数，都是在持有锁的时候进行 IO 操作(访问 etcd)。
当因为网络或其他原因，访问 etcd 很慢时，二者会相互影响，最终导致注册信息失效。

比如，当 `doCrossDCRegister` 很慢时，耗时 N 分钟，此时锁被 `doCrossDCRegister` 持有， `doRegister` 迟迟无法获得锁，最终对应 etcd 上的注册信息失效，调用方报错，无可用实例。

实际上，此两函数执行的动作，完全不必加锁。